### PR TITLE
Add Tag model, ParserTags class, and tests

### DIFF
--- a/src/DataModel/Citation.php
+++ b/src/DataModel/Citation.php
@@ -33,7 +33,7 @@ class Citation
      */
     private string $originalText;
 
-    private Attribute $attrs;
+    public Attribute $attrs;
 
     private bool $selfClosing = false;
     /**
@@ -131,10 +131,15 @@ class Citation
     public function toString(): string
     {
         $attrs = $this->attrs->toString();
-        if ($this->selfClosing && $this->content === "") {
-            return "<" . $this->tagname . "" . trim($attrs) . "/>";
+        $attrsStr = trim($attrs);
+        if ($this->selfClosing && trim($this->content) === "") {
+            return "<" . $this->tagname . "" . $attrsStr . "/>";
         }
-        $space = (trim($attrs) != "") ? " " : "";
-        return "<" . $this->tagname . $space . trim($attrs) . ">" . $this->content . "</" . trim($this->tagname) . ">";
+        $space = ($attrsStr != "") ? " " : "";
+        return "<" . $this->tagname . $space . $attrsStr . ">" . $this->content . "</" . trim($this->tagname) . ">";
+    }
+    public function __toString(): string
+    {
+        return $this->toString();
     }
 }

--- a/src/DataModel/Citation.php
+++ b/src/DataModel/Citation.php
@@ -78,7 +78,7 @@ class Citation
      *
      * @return string The attributes of the citation.
      */
-    public function getAttributes(): string
+    public function getAttributesArray(): string
     {
         return $this->attributes;
     }

--- a/src/DataModel/Citation.php
+++ b/src/DataModel/Citation.php
@@ -14,20 +14,22 @@ use WikiConnect\ParseWiki\DataModel\Attribute;
 class Citation
 {
     /**
-     * @var string The name of the tag.
+     * The name.
+     *
+     * @var string The name.
      */
     private string $tagname;
     /**
-     * @var string The content of the citation.
+     * @var string The content.
      */
     private string $content;
 
     /**
-     * @var string The attributes of the citation.
+     * @var string The attributes.
      */
     private string $attributes;
     /**
-     * @var string The original, unprocessed text of the citation.
+     * @var string The original, unprocessed text.
      */
     private string $originalText;
 
@@ -37,8 +39,10 @@ class Citation
     /**
      * Citation constructor.
      *
-     * @param string $content The content of the citation.
-     * @param string $attributes The attributes of the citation.
+     * @param string $content The content.
+     * @param string $attributes The attributes.
+     * @param string $originalText The original, unprocessed text.
+     * @param bool $selfClosing Whether the citation is self-closing.
      */
     public function __construct(string $content, string $attributes = "", string $originalText = "", bool $selfClosing = false)
     {
@@ -50,23 +54,29 @@ class Citation
         $this->attrs = new Attribute($this->attributes);
     }
 
+    /**
+     * Get the name.
+     *
+     * @return string The name.
+     */
+
     public function getName(): string
     {
         return $this->tagname;
     }
     /**
-     * Get the original, unprocessed text of the citation.
+     * Get the original, unprocessed text.
      * Example: <ref name="name">{{cite web|...}}</ref>
-     * @return string The original text of the citation.
+     * @return string The original text.
      */
     public function getOriginalText(): string
     {
         return $this->originalText;
     }
     /**
-     * Get the content of the citation.
+     * Get the content.
      * Example: {{cite web|...}}
-     * @return string The content of the citation.
+     * @return string The content.
      */
     public function getContent(): string
     {
@@ -74,19 +84,9 @@ class Citation
     }
 
     /**
-     * Get the attributes of the citation.
+     * Set the content.
      *
-     * @return string The attributes of the citation.
-     */
-    public function getAttributesArray(): string
-    {
-        return $this->attributes;
-    }
-
-    /**
-     * Set the content of the citation.
-     *
-     * @param string $content The content of the citation.
+     * @param string $content The content.
      *
      * @return void
      */
@@ -94,13 +94,24 @@ class Citation
     {
         $this->content = $content;
     }
+
     /**
-     * Set the attributes of the citation.
+     * Get the attributes.
      *
-     * @param string $attributes The attributes of the citation.
+     * @return string The attributes.
+     */
+    public function getAttributesArray(): string
+    {
+        return $this->attributes;
+    }
+    /**
+     * Set the attributes.
+     *
+     * @param string $attributes The attributes.
      *
      * @return void
      */
+
     public function setAttributes(string $attributes): void
     {
         $this->attributes = $attributes;
@@ -113,7 +124,7 @@ class Citation
     }
 
     /**
-     * Convert the citation to a string using the Attribute object for attribute formatting.
+     * Convert the content to a string.
      *
      * @return string The citation as a string.
      */
@@ -121,9 +132,9 @@ class Citation
     {
         $attrs = $this->attrs->toString();
         if ($this->selfClosing && $this->content === "") {
-            return "<ref " . trim($attrs) . "/>";
+            return "<" . $this->tagname . "" . trim($attrs) . "/>";
         }
         $space = (trim($attrs) != "") ? " " : "";
-        return "<ref" . $space . trim($attrs) . ">" . $this->content . "</ref>";
+        return "<" . $this->tagname . $space . trim($attrs) . ">" . $this->content . "</" . trim($this->tagname) . ">";
     }
 }

--- a/src/DataModel/ExternalLink.php
+++ b/src/DataModel/ExternalLink.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WikiConnect\ParseWiki\DataModel;
 
 /**
@@ -12,43 +13,51 @@ class ExternalLink
 
     /**
      * ExternalLink constructor.
-     * 
+     *
      * @param string $link The URL of the external link.
      * @param string $text The display text for the link. Defaults to an empty string.
      */
-    public function __construct(string $link, string $text = "") {
+    public function __construct(string $link, string $text = "")
+    {
         $this->link = $link;
         $this->text = $text;
     }
 
     /**
      * Get the display text of the link.
-     * 
+     *
      * @return string The display text of the link.
      */
-    public function getText(): string {
+    public function getText(): string
+    {
         return $this->text;
     }
 
     /**
      * Get the URL of the link.
-     * 
+     *
      * @return string The URL of the link.
      */
-    public function getLink(): string {
+    public function getLink(): string
+    {
         return $this->link;
     }
 
     /**
      * Convert the external link to a string representation.
-     * 
+     *
      * @return string The string representation of the link in markdown format.
      */
-    public function toString(): string {
+    public function toString(): string
+    {
         if ($this->text == $this->link) {
-            return "[".$this->link."]";
+            return "[" . $this->link . "]";
         } else {
-            return "[".$this->link." ".$this->text."]";
+            return "[" . $this->link . " " . $this->text . "]";
         }
+    }
+    public function __toString(): string
+    {
+        return $this->toString();
     }
 }

--- a/src/DataModel/InternalLink.php
+++ b/src/DataModel/InternalLink.php
@@ -66,5 +66,9 @@ class InternalLink
             return "[[".$this->target."|".$this->text."]]";
         }
     }
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
 }
 

--- a/src/DataModel/Table.php
+++ b/src/DataModel/Table.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WikiConnect\ParseWiki\DataModel;
 
 /**
@@ -99,14 +100,14 @@ class Table
      */
     public function toString(): string
     {
-        $tableMarkup = "{| class=\"".$this->classes."\"" . PHP_EOL;
+        $tableMarkup = "{| class=\"" . $this->classes . "\"" . PHP_EOL;
         $tableMarkup .= "|-" . PHP_EOL;
-        
+
         for ($i = 0; $i < count($this->header); $i++) {
             if ($i + 1 == count($this->header)) {
-                $tableMarkup .= "!" . $this->header[$i] .PHP_EOL;
+                $tableMarkup .= "!" . $this->header[$i] . PHP_EOL;
             } else {
-                $tableMarkup .= "!" . $this->header[$i] .PHP_EOL;
+                $tableMarkup .= "!" . $this->header[$i] . PHP_EOL;
             }
         }
         $tableMarkup .= "|-" . PHP_EOL;
@@ -115,7 +116,7 @@ class Table
                 if ($i + 1 == count($this->header)) {
                     $tableMarkup .= "|" . $this->data[$ii][$i] . PHP_EOL;
                 } else {
-                    $tableMarkup .= "|" . $this->data[$ii][$i]. "|";
+                    $tableMarkup .= "|" . $this->data[$ii][$i] . "|";
                 }
             }
             if ($ii + 1 != count($this->data)) {
@@ -124,5 +125,9 @@ class Table
         }
         $tableMarkup .= "|}";
         return $tableMarkup;
+    }
+    public function __toString(): string
+    {
+        return $this->toString();
     }
 }

--- a/src/DataModel/Tag.php
+++ b/src/DataModel/Tag.php
@@ -14,20 +14,22 @@ use WikiConnect\ParseWiki\DataModel\Attribute;
 class Tag
 {
     /**
-     * @var string The name of the tag.
+     * The name.
+     *
+     * @var string The name.
      */
     private string $tagname;
     /**
-     * @var string The content of the tag.
+     * @var string The content.
      */
     private string $content;
 
     /**
-     * @var string The attributes of the tag.
+     * @var string The attributes.
      */
     private string $attributes;
     /**
-     * @var string The original, unprocessed text of the tag.
+     * @var string The original, unprocessed text.
      */
     private string $originalText;
 
@@ -37,10 +39,10 @@ class Tag
     /**
      * Tag constructor.
      *
-     * @param string $tagname The name of the tag.
-     * @param string $content The content of the tag.
-     * @param string $attributes The attributes of the tag.
-     * @param string $originalText The original, unprocessed text of the tag.
+     * @param string $tagname The name.
+     * @param string $content The content.
+     * @param string $attributes The attributes.
+     * @param string $originalText The original, unprocessed text.
      * @param bool $selfClosing Whether the tag is self-closing.
      */
     public function __construct(string $tagname, string $content, string $attributes = "", string $originalText = "", bool $selfClosing = false)
@@ -53,23 +55,29 @@ class Tag
         $this->attrs = new Attribute($this->attributes);
     }
 
+    /**
+     * Get the name.
+     *
+     * @return string The name.
+     */
+
     public function getName(): string
     {
         return $this->tagname;
     }
     /**
-     * Get the original, unprocessed text of the tag.
+     * Get the original, unprocessed text.
      * Example: <ref name="name">{{cite web|...}}</ref>
-     * @return string The original text of the tag.
+     * @return string The original text.
      */
     public function getOriginalText(): string
     {
         return $this->originalText;
     }
     /**
-     * Get the content of the tag.
+     * Get the content.
      * Example: {{cite web|...}}
-     * @return string The content of the tag.
+     * @return string The content.
      */
     public function getContent(): string
     {
@@ -77,19 +85,9 @@ class Tag
     }
 
     /**
-     * Get the attributes of the tag.
+     * Set the content.
      *
-     * @return string The attributes of the tag.
-     */
-    public function getAttributesArray(): string
-    {
-        return $this->attributes;
-    }
-
-    /**
-     * Set the content of the tag.
-     *
-     * @param string $content The content of the tag.
+     * @param string $content The content.
      *
      * @return void
      */
@@ -97,13 +95,24 @@ class Tag
     {
         $this->content = $content;
     }
+
     /**
-     * Set the attributes of the tag.
+     * Get the attributes.
      *
-     * @param string $attributes The attributes of the tag.
+     * @return string The attributes.
+     */
+    public function getAttributesArray(): string
+    {
+        return $this->attributes;
+    }
+    /**
+     * Set the attributes.
+     *
+     * @param string $attributes The attributes.
      *
      * @return void
      */
+
     public function setAttributes(string $attributes): void
     {
         $this->attributes = $attributes;
@@ -116,7 +125,7 @@ class Tag
     }
 
     /**
-     * Convert the tag to a string using the Attribute object for attribute formatting.
+     * Convert the content to a string.
      *
      * @return string The tag as a string.
      */

--- a/src/DataModel/Tag.php
+++ b/src/DataModel/Tag.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace WikiConnect\ParseWiki\DataModel;
+
+use WikiConnect\ParseWiki\DataModel\Attribute;
+
+/**
+ * Class Tag
+ *
+ * Represents a tag in a wikitext document.
+ *
+ * @package WikiConnect\ParseWiki\DataModel
+ */
+class Tag
+{
+    /**
+     * @var string The name of the tag.
+     */
+    private string $tagname;
+    /**
+     * @var string The content of the tag.
+     */
+    private string $content;
+
+    /**
+     * @var string The attributes of the tag.
+     */
+    private string $attributes;
+    /**
+     * @var string The original, unprocessed text of the tag.
+     */
+    private string $originalText;
+
+    private Attribute $attrs;
+
+    private bool $selfClosing = false;
+    /**
+     * Tag constructor.
+     *
+     * @param string $tagname The name of the tag.
+     * @param string $content The content of the tag.
+     * @param string $attributes The attributes of the tag.
+     * @param string $originalText The original, unprocessed text of the tag.
+     * @param bool $selfClosing Whether the tag is self-closing.
+     */
+    public function __construct(string $tagname, string $content, string $attributes = "", string $originalText = "", bool $selfClosing = false)
+    {
+        $this->tagname = $tagname;
+        $this->content = $content;
+        $this->attributes = $attributes;
+        $this->originalText = $originalText;
+        $this->selfClosing = $selfClosing;
+        $this->attrs = new Attribute($this->attributes);
+    }
+
+    public function getName(): string
+    {
+        return $this->tagname;
+    }
+    /**
+     * Get the original, unprocessed text of the tag.
+     * Example: <ref name="name">{{cite web|...}}</ref>
+     * @return string The original text of the tag.
+     */
+    public function getOriginalText(): string
+    {
+        return $this->originalText;
+    }
+    /**
+     * Get the content of the tag.
+     * Example: {{cite web|...}}
+     * @return string The content of the tag.
+     */
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * Get the attributes of the tag.
+     *
+     * @return string The attributes of the tag.
+     */
+    public function getAttributes(): string
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Set the content of the tag.
+     *
+     * @param string $content The content of the tag.
+     *
+     * @return void
+     */
+    public function setContent(string $content): void
+    {
+        $this->content = $content;
+    }
+    /**
+     * Set the attributes of the tag.
+     *
+     * @param string $attributes The attributes of the tag.
+     *
+     * @return void
+     */
+    public function setAttributes(string $attributes): void
+    {
+        $this->attributes = $attributes;
+        $this->attrs = new Attribute($this->attributes);
+    }
+
+    public function Attrs(): Attribute
+    {
+        return $this->attrs;
+    }
+
+    /**
+     * Convert the tag to a string using the Attribute object for attribute formatting.
+     *
+     * @return string The tag as a string.
+     */
+    public function toString(): string
+    {
+        $attrs = $this->attrs->toString();
+        if ($this->selfClosing && $this->content === "") {
+            return "<" . $this->tagname . "" . trim($attrs) . "/>";
+        }
+        $space = (trim($attrs) != "") ? " " : "";
+        return "<" . $this->tagname . $space . trim($attrs) . ">" . $this->content . "</" . trim($this->tagname) . ">";
+    }
+}

--- a/src/DataModel/Tag.php
+++ b/src/DataModel/Tag.php
@@ -33,7 +33,7 @@ class Tag
      */
     private string $originalText;
 
-    private Attribute $attrs;
+    public Attribute $attrs;
 
     private bool $selfClosing = false;
     /**
@@ -132,10 +132,15 @@ class Tag
     public function toString(): string
     {
         $attrs = $this->attrs->toString();
-        if ($this->selfClosing && $this->content === "") {
-            return "<" . $this->tagname . "" . trim($attrs) . "/>";
+        $attrsStr = trim($attrs);
+        if ($this->selfClosing && trim($this->content) === "") {
+            return "<" . $this->tagname . "" . $attrsStr . "/>";
         }
-        $space = (trim($attrs) != "") ? " " : "";
-        return "<" . $this->tagname . $space . trim($attrs) . ">" . $this->content . "</" . trim($this->tagname) . ">";
+        $space = ($attrsStr != "") ? " " : "";
+        return "<" . $this->tagname . $space . $attrsStr . ">" . $this->content . "</" . trim($this->tagname) . ">";
+    }
+    public function __toString(): string
+    {
+        return $this->toString();
     }
 }

--- a/src/DataModel/Tag.php
+++ b/src/DataModel/Tag.php
@@ -81,7 +81,7 @@ class Tag
      *
      * @return string The attributes of the tag.
      */
-    public function getAttributes(): string
+    public function getAttributesArray(): string
     {
         return $this->attributes;
     }

--- a/src/DataModel/Template.php
+++ b/src/DataModel/Template.php
@@ -15,22 +15,20 @@ use WikiConnect\ParseWiki\DataModel\Parameters;
 class Template
 {
     /**
-     * The name of the template.
+     * The name.
      *
-     * @var string
+     * @var string The name.
      */
     private string $name;
     /**
-     * The name of the template stripped of any underscores.
+     * The name stripped of any underscores.
      *
      * @var string
      */
     private string $nameStrip;
 
     /**
-     * The text of the template.
-     *
-     * @var string
+     * @var string The original, unprocessed text.
      */
     private string $originalText;
 
@@ -39,9 +37,9 @@ class Template
     /**
      * Template constructor.
      *
-     * @param string $name The name of the template.
-     * @param array $parameters The parameters of the template.
-     * @param string $originalText The text of the template.
+     * @param string $name The name.
+     * @param array $parameters The parameters.
+     * @param string $originalText The text.
      */
 
     public function __construct(string $name, array $parameters = [], string $originalText = "")
@@ -53,31 +51,9 @@ class Template
     }
 
     /**
-     * Get the text of the template.
+     * Get the name stripped of any underscores.
      *
-     * @return string The text of the template.
-     */
-
-    public function getOriginalText(): string
-    {
-        return $this->originalText;
-    }
-
-    /**
-     * Get the name of the template.
-     *
-     * @return string The name of the template.
-     */
-
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    /**
-     * Get the name of the template stripped of any underscores.
-     *
-     * @return string The name of the template stripped of any underscores.
+     * @return string The name stripped of any underscores.
      */
 
     public function getStripName(): string
@@ -86,9 +62,31 @@ class Template
     }
 
     /**
-     * Get the parameters of the template.
+     * Get the name.
      *
-     * @return array The parameters of the template.
+     * @return string The name.
+     */
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get the original, unprocessed text.
+     * Example: {{cite web|...}}
+     * @return string The original text.
+     */
+
+    public function getOriginalText(): string
+    {
+        return $this->originalText;
+    }
+
+    /**
+     * Get the parameters.
+     *
+     * @return array The parameters.
      */
 
     public function getParameters(): array
@@ -96,9 +94,9 @@ class Template
         return $this->parameters->getParameters();
     }
     /**
-     * Set the name of the template.
+     * Set the name.
      *
-     * @param string $name The new name of the template.
+     * @param string $name The new name.
      *
      * @return void
      */
@@ -108,6 +106,11 @@ class Template
         $this->name = $name;
     }
 
+    /**
+     * Convert the content to a string.
+     *
+     * @return string The tag as a string.
+     */
     public function toString(bool $newLine = false, $ljust = 0): string
     {
         $separator = $newLine ? "\n" : "";

--- a/src/ParserTags.php
+++ b/src/ParserTags.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace WikiConnect\ParseWiki;
+
+use WikiConnect\ParseWiki\DataModel\Tag;
+
+/**
+ * Class ParserTags
+ *
+ * Parses text to extract tags from wikitext.
+ *
+ * @package WikiConnect\ParseWiki
+ */
+class ParserTags
+{
+    /**
+     * @var string The text to parse for tags.
+     */
+    private string $text;
+    private string $tagname;
+
+    /**
+     * @var Tag[] Array of extracted tags.
+     */
+    private array $tags;
+    private array $tagsarray;
+
+    /**
+     * ParserTags constructor.
+     *
+     * Initializes the parser with the given text and starts the parsing process.
+     *
+     * @param string $text The text to parse.
+     * @param string $tagname The name of the tag to search for.
+     */
+    public function __construct(string $text, string $tagname = "")
+    {
+        $this->tagname = $tagname;
+        $this->text = $text;
+        $this->parse();
+    }
+
+    /**
+     * Find and extract tags from the given string.
+     *
+     * Uses a regular expression to match tags wrapped in <ref> tags.
+     *
+     * @param string $string The string to search for tags.
+     * @return array An array of matches found in the string.
+     */
+    private function find_sub_tags(string $string): array
+    {
+        $matches = [];
+
+        // full tags <ref>...</ref>
+        preg_match_all(
+            '/<(?<tag>[a-zA-Z0-9]+)(\s[^>]*)?>(.*?)<\/\k<tag>>/is',
+            $string,
+            $standardMatches,
+            PREG_SET_ORDER
+        );
+        foreach ($standardMatches as $match) {
+            $matches[] = [
+                'original'    => $match[0],
+                'name'        => $match['tag'],
+                'attributes'  => $match[2],
+                'content'     => $match[3],
+                'selfClosing' => false,
+            ];
+        }
+
+
+        // Self-closing tags like <ref ... />
+        preg_match_all(
+            '/<(?<tag>[a-zA-Z0-9]+ *)(\s[^>]*)?\/>/is',
+            $string,
+            $selfClosingMatches,
+            PREG_SET_ORDER
+        );
+
+        foreach ($selfClosingMatches as $match) {
+            $matches[] = [
+                'original'    => $match[0],
+                'name'        => $match['tag'],
+                'attributes'  => $match[2] ?? '',
+                'content'     => '',
+                'selfClosing' => true,
+            ];
+        }
+
+        return $matches;
+    }
+
+    /**
+     * Parse the text for tags and store them.
+     *
+     * Uses find_sub_tags to identify tags and initializes
+     * Tag objects for each one found.
+     *
+     * @return void
+     */
+    public function parse(): void
+    {
+        $text_tags = $this->find_sub_tags($this->text);
+        $this->tags = [];
+        $this->tagsarray = [];
+
+        foreach ($text_tags as $citationData) {
+            if ($this->tagname != "" && trim($citationData['name']) != trim($this->tagname)) {
+                continue;
+            }
+            $_Citation = new Tag(
+                $citationData['name'],
+                $citationData['content'],
+                $citationData['attributes'],
+                $citationData['original'],
+                $citationData['selfClosing']
+            );
+            $this->tags[] = $_Citation;
+            $this->tagsarray[] = $citationData['original'];
+        }
+    }
+
+    /**
+     * Get all tags found in the text.
+     *
+     * Returns the array of Tag objects extracted from the text.
+     *
+     * @return Tag[] Array of Tag objects.
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+    public function getTagsArray(): array
+    {
+        return $this->tagsarray;
+    }
+}

--- a/tests/ParserCitationsTest.php
+++ b/tests/ParserCitationsTest.php
@@ -36,8 +36,8 @@ class ParserCitationsTest extends TestCase
         $citations = $parser->getCitations();
 
         $this->assertCount(1, $citations);
-        $this->assertStringContainsString('name="foo"', $citations[0]->getAttributes());
-        $this->assertStringContainsString('group="bar"', $citations[0]->getAttributes());
+        $this->assertStringContainsString('name="foo"', $citations[0]->getAttributesArray());
+        $this->assertStringContainsString('group="bar"', $citations[0]->getAttributesArray());
         $this->assertEquals('Attr ref', $citations[0]->getContent());
     }
 
@@ -94,8 +94,8 @@ class ParserCitationsTest extends TestCase
         $this->assertEquals('', $citation->getContent());
 
         // تحقق من السمات
-        $this->assertStringContainsString('name="test"', $citation->getAttributes());
-        $this->assertStringContainsString('group="alpha"', $citation->getAttributes());
+        $this->assertStringContainsString('name="test"', $citation->getAttributesArray());
+        $this->assertStringContainsString('group="alpha"', $citation->getAttributesArray());
 
         // تحقق من السمات ككائن Attribute
         $attrs = $citation->Attrs();

--- a/tests/ParserTagsTest.php
+++ b/tests/ParserTagsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WikiConnect\ParseWiki\ParserTags;
+use WikiConnect\ParseWiki\DataModel\Tag;
+use WikiConnect\ParseWiki\DataModel\Attribute;
+
+class ParserTagsTest extends TestCase
+{
+    public function testSingleTag()
+    {
+        $text = '<gallery>Images go here</gallery>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(1, $tags);
+        $this->assertInstanceOf(Tag::class, $tags[0]);
+        $this->assertEquals('gallery', trim($tags[0]->getName()));
+        $this->assertEquals('Images go here', $tags[0]->getContent());
+    }
+
+    public function testMultipleDifferentTags()
+    {
+        $text = '<gallery>Images</gallery><math>E=mc^2</math><code>echo</code>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(3, $tags);
+        $this->assertEquals('gallery', trim($tags[0]->getName()));
+        $this->assertEquals('math', trim($tags[1]->getName()));
+        $this->assertEquals('code', trim($tags[2]->getName()));
+        $this->assertEquals('E=mc^2', $tags[1]->getContent());
+    }
+
+    public function testFilterByTagName()
+    {
+        $text = '<gallery>Images</gallery><ref>Ignore this</ref><gallery>More images</gallery>';
+        $parser = new ParserTags($text, 'gallery');
+        $tags = $parser->getTags();
+
+        $this->assertCount(2, $tags);
+        foreach ($tags as $tag) {
+            $this->assertEquals('gallery', trim($tag->getName()));
+        }
+    }
+
+    public function testSelfClosingSourceTag()
+    {
+        $text = '<source lang="bash" mode="console" />';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(1, $tags);
+        $tag = $tags[0];
+
+        $this->assertEquals('source', trim($tag->getName()));
+        $this->assertEquals('', $tag->getContent());
+        $this->assertTrue($tag->Attrs()->has('lang'));
+        $this->assertEquals('"bash"', $tag->Attrs()->get('lang'));
+    }
+
+    public function testTagWithUnquotedAttributes()
+    {
+        $text = '<timeline type=bar height=100>Graph</timeline>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(1, $tags);
+        $attrs = $tags[0]->Attrs();
+        $this->assertEquals('bar', $attrs->get('type'));
+        $this->assertEquals('100', $attrs->get('height'));
+    }
+
+    public function testMinimalRefTag()
+    {
+        $text = 'Example<ref>Ref content</ref>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(1, $tags);
+        $this->assertEquals('ref', trim($tags[0]->getName()));
+        $this->assertEquals('Ref content', $tags[0]->getContent());
+    }
+
+    public function testSelfClosingRefWithAttributes()
+    {
+        $text = '<ref name="x" group="g" />';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(1, $tags);
+        $tag = $tags[0];
+
+        $this->assertEquals('ref', trim($tag->getName()));
+        $this->assertEquals('', $tag->getContent());
+        $this->assertEquals('"x"', $tag->Attrs()->get('name'));
+        $this->assertEquals('"g"', $tag->Attrs()->get('group'));
+    }
+
+    public function testGetOriginalText()
+    {
+        $text = '<math>E=mc^2</math>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertEquals('<math>E=mc^2</math>', $tags[0]->getOriginalText());
+    }
+
+    public function testToStringMatchesOriginal()
+    {
+        $text = '<ref name="r1">Some ref</ref>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertEquals($text, $tags[0]->toString());
+
+        $attrs = $tags[0]->Attrs();
+        $attrs->set('novalue2', 'new');
+        $this->assertEquals('new', $attrs->get('novalue2'));
+    }
+
+    public function testNoTags()
+    {
+        $text = 'Plain text without any tags.';
+        $parser = new ParserTags($text);
+        $this->assertCount(0, $parser->getTags());
+    }
+}


### PR DESCRIPTION
Introduces the Tag data model for representing wikitext tags, the ParserTags class for extracting tags from text, and a comprehensive PHPUnit test suite for tag parsing and attribute handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to parse and extract tags from wikitext, including support for self-closing tags and attribute handling.
  * Introduced retrieval and filtering of tags by name, with access to tag content, attributes, and original text.
  * Introduced a new tag representation supporting content, attributes, and string conversion.
  * Enabled string conversion for various data models including citations, external links, internal links, and tables.
* **Bug Fixes**
  * Updated method name for citation attributes retrieval to improve consistency.
* **Tests**
  * Added comprehensive tests to validate tag parsing, attribute extraction, content retrieval, filtering, and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->